### PR TITLE
[fix] make the example build and run by invoking start.sh and removed…

### DIFF
--- a/example/shopping_cart/start.sh
+++ b/example/shopping_cart/start.sh
@@ -1,5 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-cd /home/sleipnir/development/workspace/pessoal/cloudstate-repos/cloudstate-dart-support/example/shopping_cart
+pub get
 dart --snapshot-kind=kernel --snapshot=bin/main.dart.snapshot bin/main.dart
 dart bin/main.dart.snapshot


### PR DESCRIPTION
… absolute path for the script changing to, and, having bash invoked portable.

@sleipnir started to try the dart support and found minor issues in the start.sh script so that it builds the example on my box.